### PR TITLE
Resolved memory leaks in the Backform.Form

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -87,13 +87,27 @@
         options.fields = new Fields(options.fields || this.fields);
       this.fields = options.fields;
       this.model.errorModel = options.errorModel || this.model.errorModel || new Backbone.Model();
+      this.controls = [];
+    },
+    cleanup: function() {
+      _.each(this.controls, function(c) {
+        c.remove();
+      });
+      this.controls.length = 0;
+    },
+    remove: function() {
+      /* First do the clean up */
+      this.cleanup();
+      Backbone.View.prototype.remove.apply(this, arguments);
     },
     render: function() {
+      this.cleanup();
       this.$el.empty();
 
       var form = this,
           $form = this.$el,
-          model = this.model;
+          model = this.model,
+          controls = this.controls;
 
       this.fields.each(function(field) {
         var control = new (field.get("control"))({
@@ -101,6 +115,7 @@
           model: model
         });
         $form.append(control.render().$el);
+        controls.push(control);
       });
 
       return this;


### PR DESCRIPTION
Problem Description:
The controls created by the Backform.Form were not kept tracked, and
were never been released on rerendering the form or removal of the form.

Resolution:
- Keep track of all the controls created by the Backform.Form
- Introduced a function 'cleanup' to do the clean up work, and calling
  it from rendering, so that - it can remove existing controls before
  adding new one.
- Also, override the Backbone.View.prototype.remove function to do
  proper clean up work on removal of the form.

Thanks to [Martin Drapeau] (https://github.com/martindrapeau) for his [guidance, and help](https://github.com/AmiliaApp/backform/pull/20).
