### PR TITLE
Support for the enabling/disabling, required option, visibility change of a control, when some other attributes get changed in the model

### DIFF
--- a/example.js
+++ b/example.js
@@ -115,16 +115,11 @@ $(document).ready(function() {
     }, {
       name: "years",
       label: "For how many years?",
+      disabled: function(m) { return m && m.get("toggle"); },
       control: Backform.InputControl.extend({
         initialize: function() {
           Backform.InputControl.prototype.initialize.apply(this, arguments);
           this.listenTo(this.model, "change:toggle", this.render);
-        },
-        render: function() {
-          if (this.model.get("toggle"))
-            return Backform.InputControl.prototype.render.apply(this, arguments);
-          this.$el.empty();
-          return this;
         }
       })
     }]
@@ -142,31 +137,15 @@ $(document).ready(function() {
     }, {
       name: "years",
       label: "For how many years?",
-      deps: ["toggle"],
       visible: function(m) {
           return m && m.get("toggle");
       },
-      control: Backform.InputControl
-    }]
-  }).render();
-
-  // Example with question (disable attribute)
-  new Backform.Form({
-    el: $("#form-disabled"),
-    model: new Backbone.Model({toggle: false, years: 0}),
-    fields: [{
-      name: "toggle",
-      label: "Are you a programmer?",
-      control: "radio",
-      options: [{label: "Yes", value: true}, {label: "No", value: false}]
-    }, {
-      name: "years",
-      label: "For how many years?",
-      deps: ["toggle"],
-      disabled: function(m) {
-          return m && !m.get("toggle");
-      },
-      control: Backform.InputControl
+      control: Backform.InputControl.extend({
+        initialize: function() {
+          Backform.InputControl.prototype.initialize.apply(this, arguments);
+          this.listenTo(this.model, "change:toggle", this.render);
+        }
+      })
     }]
   }).render();
 

--- a/example.js
+++ b/example.js
@@ -130,6 +130,46 @@ $(document).ready(function() {
     }]
   }).render();
 
+  // Example with question (visible attribute)
+  new Backform.Form({
+    el: $("#form-visible"),
+    model: new Backbone.Model({toggle: false, years:0}),
+    fields: [{
+      name: "toggle",
+      label: "Are you a programmer?",
+      control: "radio",
+      options: [{label: "Yes", value: true}, {label: "No", value: false}]
+    }, {
+      name: "years",
+      label: "For how many years?",
+      deps: ["toggle"],
+      visible: function(m) {
+          return m && m.get("toggle");
+      },
+      control: Backform.InputControl
+    }]
+  }).render();
+
+  // Example with question (disable attribute)
+  new Backform.Form({
+    el: $("#form-disabled"),
+    model: new Backbone.Model({toggle: false, years:0}),
+    fields: [{
+      name: "toggle",
+      label: "Are you a programmer?",
+      control: "radio",
+      options: [{label: "Yes", value: true}, {label: "No", value: false}]
+    }, {
+      name: "years",
+      label: "For how many years?",
+      deps: ["toggle"],
+      disabled: function(m) {
+          return m && !m.get("toggle");
+      },
+      control: Backform.InputControl
+    }]
+  }).render();
+
   // Example with input of type email
   new Backform.Form({
     el: $("#form-email"),

--- a/example.js
+++ b/example.js
@@ -106,7 +106,7 @@ $(document).ready(function() {
   // Example with question
   window.f = new Backform.Form({
     el: $("#form-question"),
-    model: new Backbone.Model({toggle: false, years:0}),
+    model: new Backbone.Model({toggle: false, years: 0}),
     fields: [{
       name: "toggle",
       label: "Are you a programmer?",
@@ -133,7 +133,7 @@ $(document).ready(function() {
   // Example with question (visible attribute)
   new Backform.Form({
     el: $("#form-visible"),
-    model: new Backbone.Model({toggle: false, years:0}),
+    model: new Backbone.Model({toggle: false, years: 0}),
     fields: [{
       name: "toggle",
       label: "Are you a programmer?",
@@ -153,7 +153,7 @@ $(document).ready(function() {
   // Example with question (disable attribute)
   new Backform.Form({
     el: $("#form-disabled"),
-    model: new Backbone.Model({toggle: false, years:0}),
+    model: new Backbone.Model({toggle: false, years: 0}),
     fields: [{
       name: "toggle",
       label: "Are you a programmer?",

--- a/index.html
+++ b/index.html
@@ -583,7 +583,7 @@ var SelectControl = Backform.SelectControl = Control.extend({
           <pre id="form-question-code" style="display:none;">
 new Backform.Form({
   el: $("#form-question"),
-  model: new Backbone.Model({toggle: true, years:0}),
+  model: new Backbone.Model({toggle: true, years: 0}),
   fields: [{
     name: "toggle",
     label: "Are you a programmer?",
@@ -617,7 +617,7 @@ new Backform.Form({
 // Example with question (visible attribute)
 new Backform.Form({
   el: $("#form-visible"),
-  model: new Backbone.Model({toggle: false, years:0}),
+  model: new Backbone.Model({toggle: false, years: 0}),
   fields: [{
     name: "toggle",
     label: "Are you a programmer?",
@@ -645,7 +645,7 @@ new Backform.Form({
 // Example with question (visible attribute)
 new Backform.Form({
   el: $("#form-disabled"),
-  model: new Backbone.Model({toggle: false, years:0}),
+  model: new Backbone.Model({toggle: false, years: 0}),
   fields: [{
     name: "toggle",
     label: "Are you a programmer?",

--- a/index.html
+++ b/index.html
@@ -607,6 +607,62 @@ new Backform.Form({
 }).render();
 </pre>
           <br/>
+          <h3>Visible Attribute as a function in Field</h3>
+          <p>
+            You can conditionally show a control by providing a function, which takes model as input, and returns a boolean value. For example:
+          </p>
+          <form id="form-visible" class="form-horizontal"></form>
+          <p><button class="btn btn-primary show-code" for="#form-visible-code">&lt;/&gt; Show Code</button></p>
+          <pre id="form-visible-code" style="display:none;">
+// Example with question (visible attribute)
+new Backform.Form({
+  el: $("#form-visible"),
+  model: new Backbone.Model({toggle: false, years:0}),
+  fields: [{
+    name: "toggle",
+    label: "Are you a programmer?",
+    control: "radio",
+    options: [{label: "Yes", value: true}, {label: "No", value: false}]
+  }, {
+    name: "years",
+    label: "For how many years?",
+    deps: ["toggle"],
+    visible: function(m) {
+        return m && m.get("toggle");
+    },
+    control: Backform.InputControl
+  }]
+}).render();
+</pre>
+          <br/>
+          <h3>Disabled Attribute as a function in Field</h3>
+          <p>
+            You can conditionally show a control by providing a function, which takes model as input, and returns a boolean value. For example:
+          </p>
+          <form id="form-disabled" class="form-horizontal"></form>
+          <p><button class="btn btn-primary show-code" for="#form-disabled-code">&lt;/&gt; Show Code</button></p>
+          <pre id="form-disabled-code" style="display:none;">
+// Example with question (visible attribute)
+new Backform.Form({
+  el: $("#form-disabled"),
+  model: new Backbone.Model({toggle: false, years:0}),
+  fields: [{
+    name: "toggle",
+    label: "Are you a programmer?",
+    control: "radio",
+    options: [{label: "Yes", value: true}, {label: "No", value: false}]
+  }, {
+    name: "years",
+    label: "For how many years?",
+    deps: ["toggle"],
+    disabled: function(m) {
+        return m && !m.get("toggle");
+    },
+    control: Backform.InputControl
+  }]
+}).render();
+</pre>
+          <br/>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -591,16 +591,11 @@ new Backform.Form({
   }, {
     name: "years",
     label: "For how many years?",
+    disabled: function(model) { return !model.get("toggle"); }
     control: Backform.InputControl.extend({
       initialize: function() {
         Backform.InputControl.prototype.initialize.apply(this, arguments);
         this.listenTo(this.model, "change:toggle", this.render);
-      },
-      render: function() {
-        if (this.model.get("toggle"))
-          return Backform.InputControl.prototype.render.apply(this, arguments);
-        this.$el.empty();
-        return this;
       }
     })
   }]
@@ -627,38 +622,13 @@ new Backform.Form({
     name: "years",
     label: "For how many years?",
     deps: ["toggle"],
-    visible: function(m) {
-        return m && m.get("toggle");
-    },
-    control: Backform.InputControl
-  }]
-}).render();
-</pre>
-          <br/>
-          <h3>Disabled Attribute as a function in Field</h3>
-          <p>
-            You can conditionally show a control by providing a function, which takes model as input, and returns a boolean value. For example:
-          </p>
-          <form id="form-disabled" class="form-horizontal"></form>
-          <p><button class="btn btn-primary show-code" for="#form-disabled-code">&lt;/&gt; Show Code</button></p>
-          <pre id="form-disabled-code" style="display:none;">
-// Example with question (visible attribute)
-new Backform.Form({
-  el: $("#form-disabled"),
-  model: new Backbone.Model({toggle: false, years: 0}),
-  fields: [{
-    name: "toggle",
-    label: "Are you a programmer?",
-    control: "radio",
-    options: [{label: "Yes", value: true}, {label: "No", value: false}]
-  }, {
-    name: "years",
-    label: "For how many years?",
-    deps: ["toggle"],
-    disabled: function(m) {
-        return m && !m.get("toggle");
-    },
-    control: Backform.InputControl
+    visible: function(model) { return model.get("toggle");},
+    control: Backform.InputControl.extend({
+      initialize: function() {
+        Backform.InputControl.prototype.initialize.apply(this, arguments);
+        this.listenTo(this.model, "change:toggle", this.render);
+      }
+    })
   }]
 }).render();
 </pre>

--- a/src/backform.js
+++ b/src/backform.js
@@ -39,6 +39,7 @@
     helpClassName: "help-block",
     errorClassName: "has-error",
     helpMessageClassName: "help-block",
+    hiddenClassname: "hidden",
 
     // Bootstrap 2.3 adapter
     bootstrap2: function() {
@@ -336,10 +337,10 @@
       _.extend(data, evalF(data, this.model));
 
       /* Clean up first */
-      this.$el.removeClass('hidden');
+      this.$el.removeClass(Backform.hiddenClassname);
 
       if (!data.visible)
-        this.$el.addClass('hidden');
+        this.$el.addClass(Backform.hiddenClassname);
 
       this.$el.html(this.template(data)).addClass(field.name);
       this.updateInvalid();

--- a/src/backform.js
+++ b/src/backform.js
@@ -322,19 +322,16 @@
             attributes: attributes,
             formatter: this.formatter
           }),
-          evalF = function(data, model) {
-            var e = function(f, m) {
-                  return (_.isFunction(f) ? !!f(m) : !!f);
-                };
-            return {
-              disabled: e(data.disabled, model),
-              visible:  e(data.visible, model),
-              required: e(data.required, model)
-            }
+          evalF = function(f, m) {
+            return (_.isFunction(f) ? !!f(m) : !!f);
           };
 
       /* Evaluate the disabled, visible, and required option */
-      _.extend(data, evalF(data, this.model));
+      _.extend(data, {
+        disabled: evalF(data.disabled, this.model),
+        visible:  evalF(data.visible, this.model),
+        required: evalF(data.required, this.model)
+      });
 
       /* Clean up first */
       this.$el.removeClass(Backform.hiddenClassname);

--- a/src/backform.js
+++ b/src/backform.js
@@ -215,7 +215,7 @@
       // List of dependents
       deps: []
     },
-    initialize: function(o1, o2) {
+    initialize: function(attributes, options) {
       var control = Backform.resolveNameToClass(this.get("control"), "Control");
       this.set({control: control}, {silent: true});
     }
@@ -244,8 +244,7 @@
       // Back-reference to the field
       this.field = options.field;
 
-      var formatter = Backform.resolveNameToClass(
-        this.field.get("formatter") || this.formatter, "Formatter");
+      var formatter = Backform.resolveNameToClass(this.field.get("formatter") || this.formatter, "Formatter");
       if (!_.isFunction(formatter.fromRaw) && !_.isFunction(formatter.toRaw)) {
         formatter = new formatter();
       }
@@ -254,16 +253,14 @@
       var attrArr = this.field.get('name').split('.');
       var name = attrArr.shift();
 
-      /* Listen to the field in the model for any change */
+      // Listen to the field in the model for any change
       this.listenTo(this.model, "change:" + name, this.render);
 
-      /* Listen for the field in the error model for any change */
-      if (this.model.errorModel instanceof Backbone.Model) {
-        this.listenTo(this.model.errorModel, "change:" + name,
-            this.updateInvalid);
-      }
+      // Listen for the field in the error model for any change
+      if (this.model.errorModel instanceof Backbone.Model)
+        this.listenTo(this.model.errorModel, "change:" + name, this.updateInvalid);
 
-      /* Listen to the dependent fields in the model for any change */
+      // Listen to the dependent fields in the model for any change
       var deps = this.field.get('deps');
       var that = this;
       if (deps && _.isArray(deps)) {
@@ -277,9 +274,7 @@
     },
     formatter: ControlFormatter,
     getValueFromDOM: function() {
-      return this.formatter.toRaw(
-          this.$el.find(".uneditable-input").text(),
-          this.model);
+      return this.formatter.toRaw(this.$el.find(".uneditable-input").text(), this.model);
     },
     onChange: function(e) {
       var model = this.model,
@@ -326,14 +321,14 @@
             return (_.isFunction(f) ? !!f(m) : !!f);
           };
 
-      /* Evaluate the disabled, visible, and required option */
+      // Evaluate the disabled, visible, and required option
       _.extend(data, {
         disabled: evalF(data.disabled, this.model),
         visible:  evalF(data.visible, this.model),
         required: evalF(data.required, this.model)
       });
 
-      /* Clean up first */
+      // Clean up first
       this.$el.removeClass(Backform.hiddenClassname);
 
       if (!data.visible)
@@ -644,7 +639,3 @@
   return Backform;
 
 }));
-
-/* VIM:
- * :se shiftwidth=2 tabstop=2 expandtab smartindent textwidth=79
- */

--- a/src/backform.js
+++ b/src/backform.js
@@ -211,9 +211,7 @@
       value: undefined,
       // Control or class name for the control representing this field
       control: undefined,
-      formatter: undefined,
-      // List of dependents
-      deps: []
+      formatter: undefined
     },
     initialize: function(attributes, options) {
       var control = Backform.resolveNameToClass(this.get("control"), "Control");
@@ -259,18 +257,6 @@
       // Listen for the field in the error model for any change
       if (this.model.errorModel instanceof Backbone.Model)
         this.listenTo(this.model.errorModel, "change:" + name, this.updateInvalid);
-
-      // Listen to the dependent fields in the model for any change
-      var deps = this.field.get('deps');
-      var that = this;
-      if (deps && _.isArray(deps)) {
-          _.each(deps, function(d) {
-              attrArr = d.split('.');
-              name = attrArr.shift();
-
-              that.listenTo(that.model, "change:" + name, that.render);
-          });
-      }
     },
     formatter: ControlFormatter,
     getValueFromDOM: function() {

--- a/src/backform.js
+++ b/src/backform.js
@@ -227,7 +227,7 @@
 
   // Base Control class
   var Control = Backform.Control = Backbone.View.extend({
-    /* Additional field defaults */
+    // Additional field defaults
     defaults: {},
     className: function() {
       return Backform.groupClassName;


### PR DESCRIPTION
The current implementation does not allow to re-render the control, when some other attribute has been changed in the model, and also does not change attributes (i.e. required, disabled, visibility) of the control.

I've modified the Field:
1. Introduced new attributes.
  - visible (boolean):
     Show/Hide the control
  - deps (array of name of attributes of the model):
    Re-render the control on change of the attributes in the model
2. Allow to use function/boolean value for required, disabled, visible
  These attributes will be evaluated to boolean value from the function before rendering the control.

Also, modified the Control:
- Evaluate the required, visible, and disabled attributes during rendering the control.

I've also modified the documentations.