### PR TITLE
Allow BackForm to work with Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	"files": [
 		"src/backform.js"
 	],
+	"browser": "./src/backform.js",
 	"license": {
 		"type": "MIT",
 		"url": "https://github.com/AmiliaApp/backform/blob/gh-pages/LICENSE"


### PR DESCRIPTION
Added a hint to package.json that allows Browserify to be able to load Backform.