### PR TITLE
Render asterisk bugfix

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -299,7 +299,7 @@
     },
     renderAsteriskIfRequired: function() {
       if (this.showAsterisk) {
-        this.$el.find('label.' + Backform.controlLabelClassName).append(' *');
+        this.$el.find('label.' + Backform.controlLabelClassName.replace(" ", ".")).append(' *');
       }
     },
     render: function() {


### PR DESCRIPTION
* This PR aims to solve a bug found in the case :

Having
`renderAsteriskIfRequired: function() {
      if (this.showAsterisk) {
        this.$el.find('label.' + Backform.controlLabelClassName).append(' *');
      }
    },`

the query will never find an element if it has more than one css class. 
That's because it will translate to something like: `this.$el.find('label.control-label col-sm-4')` instead of `this.$el.find('label.control-label.col-sm-4')`. 
By replacing the space with the `.` in the string the problem is solved.
