### PR TITLE
Using ('label') to query element for renderAsterisk

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -299,7 +299,7 @@
     },
     renderAsteriskIfRequired: function() {
       if (this.showAsterisk) {
-        this.$el.find('label.' + Backform.controlLabelClassName.replace(" ", ".")).append(' *');
+        this.$el.find('label').append(' *');
       }
     },
     render: function() {


### PR DESCRIPTION
As pointed out by Josh, a control probably doesn't have more than one label, so we're safe to simplify the code.