### PR TITLE
Fixes the license value in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
 	"files": [
 		"src/backform.js"
 	],
-	"license": {
-		"type": "MIT",
-		"url": "https://github.com/AmiliaApp/backform/blob/gh-pages/LICENSE"
-	},
+	"license": "MIT",
 	"readme": "Backform takes a Backbone model and transforms it into an HTML form. Any changes to the form are relfected back to the model and vice versa. It comes with built-in controls for input, select, radio buttons, checkbox, etc. Backform controls are Backbone views and extensible. Backform even supports nested objects. Backform is built with Bootstrap 3 markup. Supports Bootstrap 2.3. Adaptable to any markup framework.\nDocumentation and examples available here: http://amiliaapp.github.io/backform/"
 }


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)