### PR TITLE
Using deeply cloned objects in onChange event to prevent inaccurate p…

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -290,7 +290,7 @@
         }
       }
 
-      changes[name] = _.isEmpty(path) ? value : _.clone(model.get(name)) || {};
+      changes[name] = _.isEmpty(path) ? value : $.extend(true, {}, model.get(name)) || {};
 
       if (!_.isEmpty(path)) this.keyPathSetter(changes[name], path, value);
       this.stopListening(this.model, 'change:' + name, this.render);


### PR DESCRIPTION
…ersistence of deeply-nested objects within models.