### PR TITLE
Fix asterisk rendering on Boolean control

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -593,6 +593,11 @@
     ].join('\n')),
     getValueFromDOM: function() {
       return this.formatter.toRaw(this.$el.find('input').is(':checked'), this.model);
+    },
+    renderAsteriskIfRequired: function() {
+      if (this.showAsterisk) {
+        this.$el.find('.checkbox label').append(' *');
+      }
     }
   });
 


### PR DESCRIPTION
Remove the left asterisk for required boolean controls. Only keep the right one.

![remove-asterisk-boolean](https://cloud.githubusercontent.com/assets/502431/19481849/4d8eeb0c-951d-11e6-9131-5e7b08114ff8.PNG)