### PR TITLE
prevent datepicker to trigger changes verbose

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -655,6 +655,12 @@
       'changeDate input': 'onChange',
       'focus input': 'clearInvalid'
     }),
+    onChange : function(e) {
+      if($(e.target).val() !==  this.model.get(this.field.get('name'))){
+        InputControl.prototype.onChange.apply(this, arguments);
+      }
+      return;
+    },
     render: function() {
       InputControl.prototype.render.apply(this, arguments);
       this.$el.find('input').datepicker(this.field.get('options'));


### PR DESCRIPTION
The original implementation was triggering model.set many times in a
change date event cycle, causing “model.changed” hash to be cleared and
(eventually) preventing a model’s date field to be rest “patched”