### PR TITLE
Graceful try...catch for JSON.parse to return undefined

### DIFF
--- a/src/backform.js
+++ b/src/backform.js
@@ -182,7 +182,11 @@
       return JSON.stringify(rawData);
     },
     toRaw: function(formattedData, model) {
-      return JSON.parse(formattedData);
+      var json = undefined;
+      try {
+        json = JSON.parse(formattedData);
+      } catch(error) {}
+      return json;
     }
   });
 


### PR DESCRIPTION
In the example, if you change Favorite Number to an empty value and submit the form, you will get an error with JSON.parse.

Modify to use a try...catch and upon failure, return undefined.